### PR TITLE
PD-45855: Updates to build in github actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Publish a release to the Maven Central Repository
+on: workflow_dispatch
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Maven Central Repository
+        uses: actions/setup-java@v4
+        with:
+          java-version: '8'
+          distribution: 'zulu'
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-passphrase: GPG_PASSPHRASE
+          gpg-private-key: ${{ secrets.GPG_SECRET_KEY }}
+      - name: Configure Git User
+        run: |
+          git config user.email "actions@github.com"
+          git config user.name "GitHub Actions"
+      - name: Publish release
+        run: mvn -Dresume=false -Prelease -B -V -U release:prepare release:perform
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,0 +1,25 @@
+name: Publish a snapshot to the Maven Central Repository
+on:
+  push:
+    branches: [ "master" ]
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Maven Central Repository
+        uses: actions/setup-java@v4
+        with:
+          java-version: '8'
+          distribution: 'zulu'
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-passphrase: GPG_PASSPHRASE
+          gpg-private-key: ${{ secrets.GPG_SECRET_KEY }}
+      - name: Publish snapshot
+        run: mvn deploy -B -C -U -Dprod -Pstyle-enforcer
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: Run tests on branch
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Maven Central Repository
+        uses: actions/setup-java@v4
+        with:
+          java-version: '8'
+          distribution: 'zulu'
+      - name: Cache Maven packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Test package
+        run: mvn verify

--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,8 @@
     </licenses>
 
     <scm>
-        <connection>scm:git:git@github.com:rapid7/presto-query-builder.git</connection>
-        <developerConnection>scm:git:git@github.com:rapid7/presto-query-builder.git</developerConnection>
+        <connection>scm:git:https://github.com/rapid7/presto-query-builder.git</connection>
+        <developerConnection>scm:git:https://github.com/rapid7/presto-query-builder.git</developerConnection>
         <url>https://github.com/rapid7/presto-query-builder</url>
         <tag>HEAD</tag>
     </scm>
@@ -138,7 +138,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.5</version>
+                        <version>1.6</version>
                         <executions>
                             <execution>
                             <id>sign-artifacts</id>
@@ -148,6 +148,13 @@
                             </goals>
                             </execution>
                         </executions>
+                        <configuration>
+                            <!-- Prevent gpg from using pinentry programs -->
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
+                        </configuration>
                     </plugin>
 
                     <plugin>


### PR DESCRIPTION
## Description
Adding github actions workflows to test, build snapshots, and build releases for this repo. This is currently done in Jenkins but is being moved over to Github action as this repo is public

## Testing
Workflows were all run in another public java repo that publishes to maven central and used the same old jenkins builds. 
<!-- For more information see: https://wiki.corp.rapid7.com/x/eSxMBg -->
