### PR TITLE
EA-18871 - Enable Renovate for repo

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "github>rapid7/renovate-config//ivm-cloud/library"
+    ]
+}


### PR DESCRIPTION
## Description
This PR adds a renovate.json file to the repo, which enables renovate to be run on it.
Renovate is a tool for automating some aspects of dependency updates. For more information see: [renovate docs](https://docs.renovatebot.com/) and [R7 Renovate wiki](https://rapid7.atlassian.net/wiki/x/2QBLLQ). 
https://rapid7.atlassian.net/browse/EA-18871