### PR TITLE
EA-21634: Change exposure group from external-ship to opensource

### DIFF
--- a/cortex.yaml
+++ b/cortex.yaml
@@ -9,7 +9,7 @@ info:
   x-cortex-tag: presto-query-builder
   x-cortex-type: service
   x-cortex-groups:
-  - exposure:external-ship
+  - exposure:opensource
   - target:library
   x-cortex-domain-parents:
   - tag: vm-data-services


### PR DESCRIPTION
## Description

PD will be scanning open source repositories in this ticket https://rapid7.atlassian.net/browse/PD-54664

## Testing
<!-- Describe how this change was tested -->

<!-- For more information see: https://wiki.corp.rapid7.com/x/eSxMBg -->
